### PR TITLE
Move `_leave` method from `rtc-signaller` to rtc-signal/signaller

### DIFF
--- a/signaller.js
+++ b/signaller.js
@@ -148,6 +148,18 @@ module.exports = function(opts, bufferMessage) {
   };
 
   /**
+    #### `_leave()`
+
+    The internal function that should be called when a peer gracefully leaves
+    the call. This will send a `/leave` message to the other peer indicating that
+    this peer connection should be closed
+
+  **/
+  signaller._leave = function() {
+    signaller.send('/leave', { id: signaller.id });
+  };
+
+  /**
     #### `_process(data)`
 
 

--- a/test/announce.js
+++ b/test/announce.js
@@ -54,3 +54,10 @@ test('reannounce second peer and ensure no additional replies are generated', fu
   t.equal(outbound.length, 0, 'no additional messages generated');
 });
 
+test('have the signaller indicate it is going to leave', function(t) {
+  t.plan(3);
+  t.equal(outbound.length, 0, 'no messages exist in outbound queue');
+  signaller._leave();
+  t.equal(outbound.length, 1, 'leave message exists');
+  t.equal(outbound[0], '/leave|' + signaller.id + '|{"id":"' + signaller.id + '"}', 'correctly formatted leave message');
+});


### PR DESCRIPTION
Moves the graceful leave behaviour from `rtc-signaller` to signaller.

This causes a `/leave` message to be sent indicating that a peer is departing, and therefore, to close all the peer connections.
